### PR TITLE
Use npm ci

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ COPY ./ /app
 
 ENV NODE_OPTIONS=--openssl-legacy-provider
 
-RUN npm install
+RUN npm ci
 RUN echo "$(date)" && \
     export $(cat /app/.env | xargs) && \
     npm run build

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ This app has been tested under Node v10.
 Install all dependencies and laucnh the development server
 
 ```shell
-npm install
+npm ci
 npm run serve
 ```
 


### PR DESCRIPTION
Use `npm ci` instead of `npm install` in order to use the lock file dependencies versions