### PR TITLE
Replace https://api-adresse.data.gouv.fr 

### DIFF
--- a/src/apps/carburants/AppCarburant.vue
+++ b/src/apps/carburants/AppCarburant.vue
@@ -582,7 +582,7 @@ export default {
       }
     },
     getAdresses() {
-        fetch('https://api-adresse.data.gouv.fr/search/?q=' + this.searchAdress.replace(' ', '%20'))
+        fetch('https://data.geopf.fr/geocodage/search/?q=' + this.searchAdress.replace(' ', '%20'))
         .then((response) => {
             return response.json()
         })

--- a/src/apps/inclusion/components/SearchBar.vue
+++ b/src/apps/inclusion/components/SearchBar.vue
@@ -62,7 +62,7 @@ export default {
   methods: {
     getAdresses() {
       fetch(
-        "https://api-adresse.data.gouv.fr/search/?q=" +
+        "https://data.geopf.fr/geocodage/search/?q=" +
           this.searchAdress.replace(" ", "%20")
       )
         .then((response) => {

--- a/src/apps/tabular/views/Table.vue
+++ b/src/apps/tabular/views/Table.vue
@@ -608,7 +608,7 @@ export default {
           this.getLocalOrFetch(
             "adresse",
             adr,
-            "https://api-adresse.data.gouv.fr/search/?q=" + adr
+            "https://data.geopf.fr/geocodage/search/?q=" + adr
           )
             .then((data) => {
               this.messageBox = data["features"][0]["properties"]["label"];

--- a/src/components/MenuFuel.vue
+++ b/src/components/MenuFuel.vue
@@ -33,7 +33,7 @@ export default {
   methods: {
     getAdresses() {
       fetch(
-        "https://api-adresse.data.gouv.fr/search/?q=" + this.searchAdress
+        "https://data.geopf.fr/geocodage/search/?q=" + this.searchAdress
       ).then((response) => {
         this.results = response.json();
       });

--- a/src/components/Table.vue
+++ b/src/components/Table.vue
@@ -547,7 +547,7 @@ export default {
           this.getLocalOrFetch(
             'adresse', 
             adr,
-            'https://api-adresse.data.gouv.fr/search/?q=' + adr
+            'https://data.geopf.fr/geocodage/search/?q=' + adr
           )
           .then((data) => {
             this.messageBox = data['features'][0]['properties']['label']


### PR DESCRIPTION
Replace https://api-adresse.data.gouv.fr with https://data.geopf.fr/geocodage for API adresse due to deprecation. Previous url will not work after the 31 January 2026, hence this PR
